### PR TITLE
Add prometheus endpoint

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/ogier/pflag v0.0.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.8.0
+	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 )

--- a/api/internal/routes/base.go
+++ b/api/internal/routes/base.go
@@ -3,16 +3,24 @@ package routes
 import (
 	"github.com/gin-contrib/static"
 	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/zekth/go_qmk/api/internal/controllers"
 	"github.com/zekth/go_qmk/api/internal/dependencies"
 	"github.com/zekth/go_qmk/api/internal/graphql"
 	"log"
 )
 
+func prometheusHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		promhttp.Handler().ServeHTTP(c.Writer, c.Request)
+	}
+}
+
 // MakeRoutes Generate the base routes of the API
 func MakeRoutes(r *gin.Engine, dependencies dependencies.Dependencies) {
 	// Serves the UI folder on the root
 	r.Use(static.Serve("/", static.LocalFile("./ui", false)))
+	r.GET("/metrics", prometheusHandler())
 	api := r.Group("/api")
 	{
 		api.GET("/ping", controllers.Ping)


### PR DESCRIPTION
Also this endpoint will gather all the new metrics we will create in the instance of the prometheus client pointer. This could be added to Dependencies object to be used in the elsewhere in the app.